### PR TITLE
Support push merged events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add --no-cache jq
+RUN apk add --no-cache curl jq
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -6,26 +6,31 @@
 
 ![screenshot](./docs/assets/screenshot-labels.png)
 
-This is a GitHub Action to output a semver update level `major, minor, patch` from a pull request *release label*.
+This is a GitHub Action to output a semver update level `major`, `minor`, `patch` from a pull request *release label*.
 
 For example, if a pull request has the label `release/minor`, this action outputs `minor` as level.
 
 It would be more useful to use this with other GitHub Actions' outputs.
-
 It's recommended to use this with [actions-ecosystem/action-bump-semver](https://github.com/actions-ecosystem/action-bump-semver) and [actions-ecosystem/action-push-tag](https://github.com/actions-ecosystem/action-push-tag).
+
+This action supports `pull_request` and `push` (merged with a pull request) events.
 
 ## Prerequisites
 
-It's necessary to create labels with the `inputs.label_prefix` prefix and the `major, minor, patch` suffix before getting started with this action.
+It's necessary to create labels with the `inputs.label_prefix` prefix and the `major`, `minor`, `patch` suffix before getting started with this action.
 
 By default, they're `release/major`, `release/minor`, and `release/patch`.
 
 ## Inputs
 
-|      NAME      |                               DESCRIPTION                               |   TYPE   | REQUIRED |            DEFAULT            |
-|----------------|-------------------------------------------------------------------------|----------|----------|-------------------------------|
-| `label_prefix` | A prefix for labels that indicate semver level `{major, minor, patch}`. | `string` | `false`  | `release/`                    |
-| `event`        | An event that triggers this action. Must be a pull request event.       | `string` | `false`  | `${{ toJson(github.event) }}` |
+|      NAME      |                                DESCRIPTION                                 |   TYPE   | REQUIRED |  DEFAULT   |
+| -------------- | -------------------------------------------------------------------------- | -------- | -------- | ---------- |
+| `label_prefix` | A prefix for labels that indicate semver level `{major, minor, patch}`.    | `string` | `false`  | `release/` |
+| `github_token` | A GitHub token. Required for `push` events, not for `pull_request` events. | `string` | `false`  | `N/A`      |
+
+If you configure a workflow with this action for `push` events, you must set `inputs.github_token`.
+
+ref: [Events that trigger workflows - GitHub Help - Pull request events for forked repositories](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories)
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ By default, they're `release/major`, `release/minor`, and `release/patch`.
 
 If you configure a workflow with this action for `push` events, you must set `inputs.github_token`.
 
-ref: [Events that trigger workflows - GitHub Help - Pull request events for forked repositories](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories)
-
 ## Outputs
 
 |  NAME   |                  DESCRIPTION                   |   TYPE   |

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,9 @@ inputs:
     description: A prefix for labels that indicate semver level ({major, minor, patch}).
     required: false
     default: "release/"
-  event:
-    description: An event that triggers this action. Must be a pull request event.
+  github_token:
+    description: A GitHub token. Required for push events, not for pull_request events.
     required: false
-    default: ${{ toJson(github.event) }}
 outputs:
   level:
     description: A semver update level ({major, minor, patch}).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,21 +2,55 @@
 
 set -e
 
-event=${INPUT_EVENT}
 prefix=${INPUT_LABEL_PREFIX}
+github_token=${INPUT_GITHUB_TOKEN}
 
-label=$(echo "${event}" | jq -r ".pull_request.labels[].name | select(test(\"$prefix(major|minor|patch)\"))")
+run() {
+    pull_request=''
 
-if [ -z "${label}" ]; then
-    echo "::debug:: no release label"
-    exit 0
-fi
+    case "${GITHUB_EVENT_NAME}" in
+    'push')
+        pull_request="$(fetch_merged_pull_request)"
+        ;;
+    'pull_request')
+        pull_request="$(jq '.pull_request' "${GITHUB_EVENT_PATH}")"
+        ;;
+    *)
+        echo "::debug:: event ${GITHUB_EVENT_NAME} not supported"
+        ;;
+    esac
 
-if [ "$(echo "${label}" | wc -l)" -ne 1 ]; then
-    echo "::error:: multiple release labels not allowed: labels=$(echo "${label}" | tr '\n' ',')"
-    exit 1
-fi
+    if [ -z "${pull_request}" ]; then
+        echo "::error:: failed to get pull request event"
+    fi
 
-level=${label#"${prefix}"} # e.g.) 'release/major' => 'major'
+    label=$(echo "${pull_request}" | jq -r ".labels[].name | select(test(\"$prefix(major|premajor|minor|preminor|patch|prepatch|prerelease)\"))")
 
-echo "::set-output name=level::${level}"
+    if [ -z "${label}" ]; then
+        echo "::debug:: no release label"
+        exit 0
+    fi
+
+    if [ "$(echo "${label}" | wc -l)" -ne 1 ]; then
+        echo "::error:: multiple release labels not allowed: labels=$(echo "${label}" | tr '\n' ',')"
+        exit 1
+    fi
+
+    level=${label#"${prefix}"} # e.g.) 'release/major' => 'major'
+
+    echo "::set-output name=level::${level}"
+}
+
+fetch_merged_pull_request() {
+    if [ -z "${github_token}" ]; then
+        echo "::error:: github token is required for push event"
+        exit 1
+    fi
+
+    curl -s \
+        -H "Authorization: token ${github_token}" \
+        "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?state=closed&sort=updated&direction=desc" |
+        jq -r ".[] | select(.merge_commit_sha==\"${GITHUB_SHA}\")"
+}
+
+run


### PR DESCRIPTION
## Release Note

```release_note
## What's New

- Supports `push` events (only merged)
- Adds `inputs.github_token`
```