### PR TITLE
Use GITHUB_OUTPUT

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,4 +43,4 @@ fi
 
 level=${label#"${prefix}"} # e.g.) 'release/major' => 'major'
 
-echo "::set-output name=level::${level}"
+echo "level=${level}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What this PR does / Why we need it

set-output was deprecated.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Which issue(s) this PR fixes

Fixes #
