### PR TITLE
Support pull_request_target events

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For example, if a pull request has the label `release/minor`, this action output
 It would be more useful to use this with other GitHub Actions' outputs.
 It's recommended to use this with [actions-ecosystem/action-bump-semver](https://github.com/actions-ecosystem/action-bump-semver) and [actions-ecosystem/action-push-tag](https://github.com/actions-ecosystem/action-push-tag).
 
-This action supports `pull_request` and `push` events.
+This action supports `pull_request`, `pull_request_target`, and `push` events.
 
 ## Prerequisites
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ case "${GITHUB_EVENT_NAME}" in
     done
     ;;
 
-'pull_request')
+'pull_request' | 'pull_request_target')
     label=$(jq -r ".pull_request.labels[].name | select(test(\"$prefix(major|minor|patch)\"))" "${GITHUB_EVENT_PATH}")
     ;;
 


### PR DESCRIPTION
## What this PR does / Why we need it

In #10, one of this action's workflows was modified to be triggered by the `pull_request_target` event, and similar changes have been made in other actions-ecosystem repositories as well, but this action does not actually support this event. Since `pull_request_target` is considered safer than `pull_request` and also allows execution from forks, I believe it would be more appropriate to update the action's code rather than the workflows.

## Which issue(s) this PR fixes

Fixes no issues
